### PR TITLE
Title Trigger for skipTitle option

### DIFF
--- a/server.js
+++ b/server.js
@@ -138,7 +138,7 @@ async function work(body) {
     withLabel: '',
     skipCollaboratorPR: false,
   };
-  
+
   if (process.env.MENTION_BOT_CONFIG) {
     try {
       repoConfig = {
@@ -190,10 +190,16 @@ async function work(body) {
       return false;
     }
 
-    if (repoConfig.skipTitle &&
-        data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
-      console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle);
-      return false;
+    if (repoConfig.skipTitle && data.changes) {
+      if ('title' in data.changes) {
+        if (data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
+          console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle);
+          return false;
+        }
+      } else {
+        console.log('Skipping because something other than the title was edited.');
+        return false;
+      }
     }
 
     if (repoConfig.skipCollaboratorPR) {
@@ -224,12 +230,6 @@ async function work(body) {
 
     if (repoConfig.userBlacklistForPR.indexOf(data.pull_request.user.login) >= 0) {
       console.log('Skipping because blacklisted user created Pull Request.');
-      return false;
-    }
-
-    if (repoConfig.skipTitle &&
-        data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
-      console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle);
       return false;
     }
 


### PR DESCRIPTION
The `skipTitle` option requires the `edited` action so that events are processed when the **Title** of the PR is changed.  Unfortunately, the `edited` action is triggered for body updates and other edits to the PR which makes mention-bot extremely annoying.

This PR allows for the use of `skipTitle` to silence mention-bot for PR's with "WIP" in the title and when the title is updated to remove "WIP", mention-bot will notify the applicable developers as intended.

Since this use case is semi-custom for Dox, I propose we don't merge upstream.